### PR TITLE
disabled mysql; chk if modules already running

### DIFF
--- a/cmd/install.go
+++ b/cmd/install.go
@@ -98,9 +98,11 @@ var installCmd = &cobra.Command{
 		if dflag != "discoveryengine" {
 			// Install MySQL DB
 			installOptions.Namespace = namespace
+			/* disabling mysql since discovery-engine now uses sqlite3
 			if err := di.MySQLInstaller(client); err != nil {
 				return err
 			}
+			*/
 
 			// Install dscovery-engine
 			diOptions.Namespace = namespace

--- a/install/install.go
+++ b/install/install.go
@@ -308,13 +308,12 @@ func DiscoveryEngineInstaller(c *k8s.Client, o Options) error {
 			metav1.CreateOptions{},
 		)
 	if err != nil {
-		panic(err.Error())
-	}
-
-	fmt.Printf("Created ConfigMap %s/%s\n", namespace, created.GetName())
-
-	if !reflect.DeepEqual(created.Data, cm.Data) {
-		panic("Created ConfigMap has unexpected data")
+		fmt.Printf("%s\n", err.Error())
+		if !reflect.DeepEqual(created.Data, cm.Data) {
+			fmt.Print("WARN: existing ConfigMap has different data from the default one, not overwriting\n")
+		}
+	} else {
+		fmt.Printf("Created ConfigMap %s/%s\n", namespace, created.GetName())
 	}
 
 	// discovery-engine Deployment


### PR DESCRIPTION
* check if discory-engine is running and not install it
* disabled mysql .. discovery engine now uses sqlite3

Signed-off-by: Rahul Jadhav <nyrahul@gmail.com>